### PR TITLE
Optimize Dockerfile, add amd64!

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,16 @@
-FROM --platform=linux/amd64 node:19-buster-slim as build
+FROM node:19-buster-slim as build
 WORKDIR /app
 
-COPY package.json package-lock.json .
+RUN apt-get update -y && apt-get install -y openssl python3 build-essential make gcc
+
+COPY package.json package-lock.json ./
 RUN npm i
+
+RUN apt-get purge -y gcc make build-essential && apt-get autoremove -y
 
 COPY src/ src/
 COPY prisma/schema.prisma prisma/
-COPY tsconfig.json .
-
-RUN apt-get update -y && apt-get install -y openssl
+COPY tsconfig.json ./
 
 RUN npx prisma generate
 


### PR DESCRIPTION
Removing "--platform=" and slightly re-structuring the "apt-get" calls allows for this image to be successfuly built for arm64 as well - at least on an arm64 host.

Successfuly built it on my system and it's working too! The reason I did that is because Prisma currently doesn't know what to do on OpenWrt; it pulls Debian binaries by default, which use glibc - whilst OpenWrt runs on musl, breaking compatibility in many ways. So, I adapted the Dockerfile to work around that.

Long-term plan is to use docker-compose - raw docker CLI feels tedious... But, one thing at a time.